### PR TITLE
Add support for pragma deprecate

### DIFF
--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -1130,7 +1130,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     b.firstOf(
                             b.sequence(b.firstOf(IS, AS), OBJECT),
                             b.sequence(UNDER, UNIT_NAME)),
-                    LPARENTHESIS, b.optional(DEPRECATE_PRAGMA, COMMA), b.oneOrMore(b.firstOf(TYPE_ELEMENT_SPEC, TYPE_ATTRIBUTE), b.optional(COMMA), b.optional(DEPRECATE_PRAGMA, COMMA)), RPARENTHESIS,
+                    LPARENTHESIS, b.optional(DEPRECATE_PRAGMA, COMMA), b.oneOrMore(b.firstOf(TYPE_ELEMENT_SPEC, TYPE_ATTRIBUTE), b.optional(COMMA), b.optional(DEPRECATE_PRAGMA, b.optional(COMMA))), RPARENTHESIS,
                     b.zeroOrMore(b.optional(NOT), b.firstOf(FINAL, INSTANTIABLE)))
 
             b.rule(CREATE_TYPE).define(

--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -156,6 +156,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
     RESTRICT_REFERENCES_PRAGMA,
     UDF_PRAGMA,
     PRAGMA_DECLARATION,
+    PRAGMA_DEPRECATE,
     HOST_AND_INDICATOR_VARIABLE,
     JAVA_DECLARATION,
     C_DECLARATION,
@@ -826,6 +827,8 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     INTERFACE_PRAGMA,
                     RESTRICT_REFERENCES_PRAGMA,
                     UDF_PRAGMA))
+
+            b.rule(PRAGMA_DEPRECATE).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING), RPARENTHESIS, SEMICOLON)
 
             b.rule(DECLARE_SECTION).define(b.oneOrMore(b.firstOf(
                     PRAGMA_DECLARATION,

--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -155,8 +155,8 @@ enum class PlSqlGrammar : GrammarRuleKey {
     INTERFACE_PRAGMA,
     RESTRICT_REFERENCES_PRAGMA,
     UDF_PRAGMA,
+    DEPRECATE_PRAGMA,
     PRAGMA_DECLARATION,
-    PRAGMA_DEPRECATE,
     HOST_AND_INDICATOR_VARIABLE,
     JAVA_DECLARATION,
     C_DECLARATION,
@@ -820,7 +820,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
 
             b.rule(UDF_PRAGMA).define(PRAGMA, UDF, SEMICOLON)
 
-            b.rule(PRAGMA_DEPRECATE).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS, SEMICOLON)
+            b.rule(DEPRECATE_PRAGMA).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS, SEMICOLON)
 
             b.rule(PRAGMA_DECLARATION).define(b.firstOf(
                     EXCEPTION_INIT_PRAGMA,
@@ -829,7 +829,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     INTERFACE_PRAGMA,
                     RESTRICT_REFERENCES_PRAGMA,
                     UDF_PRAGMA,
-                    PRAGMA_DEPRECATE))
+                    DEPRECATE_PRAGMA))
 
             b.rule(DECLARE_SECTION).define(b.oneOrMore(b.firstOf(
                     PRAGMA_DECLARATION,

--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -820,15 +820,16 @@ enum class PlSqlGrammar : GrammarRuleKey {
 
             b.rule(UDF_PRAGMA).define(PRAGMA, UDF, SEMICOLON)
 
+            b.rule(PRAGMA_DEPRECATE).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS, SEMICOLON)
+
             b.rule(PRAGMA_DECLARATION).define(b.firstOf(
                     EXCEPTION_INIT_PRAGMA,
                     AUTONOMOUS_TRANSACTION_PRAGMA,
                     SERIALLY_REUSABLE_PRAGMA,
                     INTERFACE_PRAGMA,
                     RESTRICT_REFERENCES_PRAGMA,
-                    UDF_PRAGMA))
-
-            b.rule(PRAGMA_DEPRECATE).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS, SEMICOLON)
+                    UDF_PRAGMA,
+                    PRAGMA_DEPRECATE))
 
             b.rule(DECLARE_SECTION).define(b.oneOrMore(b.firstOf(
                     PRAGMA_DECLARATION,

--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -828,7 +828,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     RESTRICT_REFERENCES_PRAGMA,
                     UDF_PRAGMA))
 
-            b.rule(PRAGMA_DEPRECATE).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING), RPARENTHESIS, SEMICOLON)
+            b.rule(PRAGMA_DEPRECATE).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS, SEMICOLON)
 
             b.rule(DECLARE_SECTION).define(b.oneOrMore(b.firstOf(
                     PRAGMA_DECLARATION,

--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -820,7 +820,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
 
             b.rule(UDF_PRAGMA).define(PRAGMA, UDF, SEMICOLON)
 
-            b.rule(DEPRECATE_PRAGMA).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS, SEMICOLON)
+            b.rule(DEPRECATE_PRAGMA).define(PRAGMA, DEPRECATE, LPARENTHESIS, EXPRESSION, b.optional(COMMA, STRING_LITERAL), RPARENTHESIS)
 
             b.rule(PRAGMA_DECLARATION).define(b.firstOf(
                     EXCEPTION_INIT_PRAGMA,
@@ -829,7 +829,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     INTERFACE_PRAGMA,
                     RESTRICT_REFERENCES_PRAGMA,
                     UDF_PRAGMA,
-                    DEPRECATE_PRAGMA))
+                    b.sequence(DEPRECATE_PRAGMA, SEMICOLON)))
 
             b.rule(DECLARE_SECTION).define(b.oneOrMore(b.firstOf(
                     PRAGMA_DECLARATION,
@@ -1130,7 +1130,7 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     b.firstOf(
                             b.sequence(b.firstOf(IS, AS), OBJECT),
                             b.sequence(UNDER, UNIT_NAME)),
-                    LPARENTHESIS, b.oneOrMore(b.firstOf(TYPE_ELEMENT_SPEC, TYPE_ATTRIBUTE), b.optional(COMMA)), RPARENTHESIS,
+                    LPARENTHESIS, b.optional(DEPRECATE_PRAGMA, COMMA), b.oneOrMore(b.firstOf(TYPE_ELEMENT_SPEC, TYPE_ATTRIBUTE), b.optional(COMMA), b.optional(DEPRECATE_PRAGMA, COMMA)), RPARENTHESIS,
                     b.zeroOrMore(b.optional(NOT), b.firstOf(FINAL, INSTANTIABLE)))
 
             b.rule(CREATE_TYPE).define(

--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlKeyword.kt
@@ -499,7 +499,8 @@ enum class PlSqlKeyword(private val value: String, val isReserved: Boolean = fal
     ERROR("error"),
     WITHOUT("without"),
     INLINE("inline"),
-    UDF("udf");
+    UDF("udf"),
+    DEPRECATE("deprecate");
 
     override fun getName() = name
 

--- a/zpa-core/src/test/kotlin/org/sonar/plugins/plsqlopen/api/declarations/PragmaDeclarationTest.kt
+++ b/zpa-core/src/test/kotlin/org/sonar/plugins/plsqlopen/api/declarations/PragmaDeclarationTest.kt
@@ -29,7 +29,7 @@ class PragmaDeclarationTest : RuleTest() {
 
     @Before
     fun init() {
-        setRootRule(PlSqlGrammar.PRAGMA_DECLARATION)
+        setRootRule(PlSqlGrammar.PRAGMA_DEPRECATE)
     }
 
     @Test
@@ -60,6 +60,12 @@ class PragmaDeclarationTest : RuleTest() {
     @Test
     fun matchesUdfPragma() {
         assertThat(p).matches("pragma udf;")
+    }
+
+    @Test
+    fun matchesPragmaDeprecate() {
+        assertThat(p).matches("pragma deprecate(object);")
+        assertThat(p).matches("pragma deprecate(object, 'object is deprecated');")
     }
 
 }

--- a/zpa-core/src/test/kotlin/org/sonar/plugins/plsqlopen/api/declarations/PragmaDeclarationTest.kt
+++ b/zpa-core/src/test/kotlin/org/sonar/plugins/plsqlopen/api/declarations/PragmaDeclarationTest.kt
@@ -29,7 +29,7 @@ class PragmaDeclarationTest : RuleTest() {
 
     @Before
     fun init() {
-        setRootRule(PlSqlGrammar.PRAGMA_DEPRECATE)
+        setRootRule(PlSqlGrammar.PRAGMA_DECLARATION)
     }
 
     @Test

--- a/zpa-core/src/test/kotlin/org/sonar/plugins/plsqlopen/api/units/CreateTypeTest.kt
+++ b/zpa-core/src/test/kotlin/org/sonar/plugins/plsqlopen/api/units/CreateTypeTest.kt
@@ -230,4 +230,61 @@ class CreateTypeTest : RuleTest() {
                         + "x number(5),"
                         + "order member function bar return number);")
     }
+
+    @Test
+    fun deprecatedType() {
+        assertThat(p).matches(
+            "create or replace type foo as object ("
+                + "  pragma deprecate (foo),"
+                + "x number(5),"
+                + "member function bar return number);")
+    }
+
+    @Test
+    fun deprecatedTypeWithComment() {
+        assertThat(p).matches(
+            "create or replace type foo as object ("
+                + "  pragma deprecate (foo, 'is deprecated'),"
+                + "x number(5),"
+                + "member function bar return number);")
+    }
+
+    @Test
+    fun deprecatedTypeVariable() {
+        assertThat(p).matches(
+            "create or replace type foo as object ("
+                + "x number(5),"
+                + "  pragma deprecate (x),"
+                + "member function bar return number);")
+    }
+
+    @Test
+    fun deprecatedTypeVariableWithComment() {
+        assertThat(p).matches(
+            "create or replace type foo as object ("
+                + "x number(5),"
+                + "  pragma deprecate (x, 'is deprecated'),"
+                + "member function bar return number);")
+    }
+
+    @Test
+    fun deprecatedTypeProcedure() {
+        assertThat(p).matches(
+            "create or replace type foo as object ("
+                + "x number(5),"
+                + "member function bar return number,"
+                + "  pragma deprecate (bar)"
+                + ");")
+    }
+
+    @Test
+    fun deprecatedTypeProcedureWithComment() {
+        assertThat(p).matches(
+            "create or replace type foo as object ("
+                + "x number(5),"
+                + "member function bar return number,"
+                + "  pragma deprecate (bar, 'is deprecated')"
+                + ");")
+    }
+
 }


### PR DESCRIPTION
With this PR I want to add the support for `pragma deprecate`.
I found out, that this is not supported while trying to create unit tests for a custom rule.

I didn't understand a lot of your code, however I added it based on what was there.
I also added the unit test for it.
However the way of doing the unit test was really strange, not sure if I did it right.

Unfortunately, I could not make any further tests than that:
1. I'm so not a maven guy and
2. I was not able to run the commands from the readme. I always received errors. (which couldn't have been related to my implementation)

Maybe it makes the way into the source :)