### PR TITLE
Use MEMBER_EXPRESSION not CUSTOM_DATATYPE in REF/ANCHORED_DATATYPE

### DIFF
--- a/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
+++ b/zpa-core/src/main/kotlin/org/sonar/plugins/plsqlopen/api/PlSqlGrammar.kt
@@ -363,13 +363,13 @@ enum class PlSqlGrammar : GrammarRuleKey {
                     b.sequence(INTERVAL, DAY, b.optional(LPARENTHESIS, DATATYPE_LENGTH, RPARENTHESIS),
                             TO, SECOND, b.optional(LPARENTHESIS, DATATYPE_LENGTH, RPARENTHESIS))))
 
-            b.rule(ANCHORED_DATATYPE).define(CUSTOM_DATATYPE, MOD, b.firstOf(TYPE, ROWTYPE))
+            b.rule(ANCHORED_DATATYPE).define(MEMBER_EXPRESSION, MOD, b.firstOf(TYPE, ROWTYPE))
 
             b.rule(CUSTOM_DATATYPE).define(
                 MEMBER_EXPRESSION,
                 b.optional(b.firstOf(NUMERIC_DATATYPE_CONSTRAINT, CHARACTER_DATATYPE_CONSTRAINT)))
 
-            b.rule(REF_DATATYPE).define(REF, CUSTOM_DATATYPE)
+            b.rule(REF_DATATYPE).define(REF, MEMBER_EXPRESSION)
 
             b.rule(DATATYPE).define(b.firstOf(
                     NUMERIC_DATATYPE,


### PR DESCRIPTION
(It appears that) both REF_DATATYPE and ANCHORED_DATATYPE can't have constraints, which CUSTOM_DATATYPE does have.
It also makes more semantic sense, as in `THE_TABLE%ROWTYPE`, `THE_TABLE` is not any custom datatype.