### PR TITLE
Fix DEFAULT ON NULL for column definition

### DIFF
--- a/zpa-checks/src/integrationTest/resources/expected/oracle-database_23/ParsingErrorCheck.json
+++ b/zpa-checks/src/integrationTest/resources/expected/oracle-database_23/ParsingErrorCheck.json
@@ -2084,9 +2084,6 @@
   "sqlrf/CREATE-TABLE-15.sql" : [
     26
   ],
-  "sqlrf/CREATE-TABLE-16.sql" : [
-    3
-  ],
   "sqlrf/CREATE-TABLE-20.sql" : [
     2
   ],

--- a/zpa-core/src/main/kotlin/com/felipebz/zpa/api/DdlGrammar.kt
+++ b/zpa-core/src/main/kotlin/com/felipebz/zpa/api/DdlGrammar.kt
@@ -154,8 +154,12 @@ enum class DdlGrammar : GrammarRuleKey {
 
             b.rule(TABLE_COLUMN_DEFINITION).define(
                     IDENTIFIER_NAME, DATATYPE,
+                    
                     b.optional(SORT),
-                    b.optional(DEFAULT, EXPRESSION),
+                    b.optional(DEFAULT, b.optional(
+                        b.sequence(ON, NULL,
+                            b.optional(FOR, INSERT,
+                                b.firstOf(ONLY, b.sequence(AND, UPDATE))))), EXPRESSION),
                     b.optional(ENCRYPT),
                     b.zeroOrMore(INLINE_CONSTRAINT))
 

--- a/zpa-core/src/test/kotlin/com/felipebz/zpa/api/ddl/AlterTableTest.kt
+++ b/zpa-core/src/test/kotlin/com/felipebz/zpa/api/ddl/AlterTableTest.kt
@@ -41,4 +41,24 @@ class AlterTableTest : RuleTest() {
     fun matchesAlterTableWithOutOfLineConstraintUsingAndTablespace() {
         assertThat(p).matches("alter table tab add constraint c_name primary key (col1, col2) using index;")
     }
+
+    @Test
+    fun matchesAlterTableAddColumnWithDefaultOnNull() {
+        assertThat(p).matches("alter table tab add col varchar2(100) default on null 'Default String';")
+    }
+
+    @Test
+    fun matchesAlterTableAddColumnWithDefaultWithoutOnNull() {
+        assertThat(p).matches("alter table tab add col varchar2(100) default 'Default String';")
+    }
+
+    @Test
+    fun matchesAlterTableAddColumnWithDefaultOnNullForInsertOnly() {
+        assertThat(p).matches("alter table tab add col varchar2(100) default on null for insert only 'Default String';")
+    }
+
+    @Test
+    fun matchesAlterTableAddColumnWithDefaultOnNullForInsertAndUpdate() {
+        assertThat(p).matches("alter table tab add col varchar2(100) default on null for insert and update 'Default String';")
+    }
 }

--- a/zpa-core/src/test/kotlin/com/felipebz/zpa/api/ddl/CreateTableTest.kt
+++ b/zpa-core/src/test/kotlin/com/felipebz/zpa/api/ddl/CreateTableTest.kt
@@ -522,4 +522,38 @@ class CreateTableTest : RuleTest() {
         assertThat(p).matches("create table table_id (id number) partition by range (column_id) subpartition by hash (column_id) (partition values less than (maxvalue) compress);")
     }
 
+    @Test
+    fun matchesColumnDefaultOnNull() {
+        assertThat(p).matches("create table table_id (id number, name varchar2(100) default on null 'Default String');")
+    }
+
+    @Test
+    fun matchesColumnDefaultOnNullWithExpression() {
+        assertThat(p).matches("create table table_id (id number, created_date date default on null sysdate);")
+    }
+
+    @Test
+    fun matchesColumnDefault() {
+        assertThat(p).matches("create table table_id (id number, name varchar2(100) default 'Default String');")
+    }
+
+    @Test
+    fun matchesColumnDefaultOnNullForInsertOnly() {
+        assertThat(p).matches("create table table_id (id number, name varchar2(100) default on null for insert only 'Default String');")
+    }
+
+    @Test
+    fun matchesColumnDefaultOnNullForInsertOnlyWithExpression() {
+        assertThat(p).matches("create table table_id (id number, created_date date default on null for insert only sysdate);")
+    }
+
+    @Test
+    fun matchesColumnDefaultOnNullForInsertAndUpdate() {
+        assertThat(p).matches("create table table_id (id number, name varchar2(100) default on null for insert and update 'Default String');")
+    }
+
+    @Test
+    fun matchesColumnDefaultOnNullForInsertAndUpdateWithExpression() {
+        assertThat(p).matches("create table table_id (id number, created_date date default on null for insert and update sysdate);")
+    }
 }


### PR DESCRIPTION
**Description**
The parser failed to recognize the DEFAULT ON NULL (including FOR INSERT ... modifiers) in CREATE TABLE and ALTER TABLE statements. This caused valid Oracle DDL not to be parsed correctly.

**Fix**
- Extended DdlGrammar to allow the ON NULL part optional within the DEFAULT clause and to support the optional FOR INSERT [ONLY|AND UPDATE] in column definition.
- Added unit tests covering the DEFAULT ON NULL exensions
- Remove "sqlrf/CREATE-TABLE-16.sql" from ParsingErrorCheck because it is now being parsed correctly.

This modification follows the Oracle Database SQL Language Reference in CREATE TABLE and ALTER TABLE: 
- https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6__CEGEDHJE
- https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/ALTER-TABLE.html#GUID-552E7373-BF93-477D-9DA3-B2C9386F2877__CIHCFDDJ